### PR TITLE
Fix GitHubRepository string representation

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -70,7 +70,9 @@ class GitHubRepository(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return self.name
+        # Use the repository URL for string representation since there is no
+        # name field defined on this model.
+        return self.github_url
 
 
 # Signal to delete repositories and unlink projects when a GitHubToken is deleted


### PR DESCRIPTION
## Summary
- return repository URL from `GitHubRepository.__str__`
- add newline at end of `models.py`

## Testing
- `python manage.py test` *(fails: pyenv version error)*

------
https://chatgpt.com/codex/tasks/task_e_68458f5bf0388321805917796c1b9678